### PR TITLE
Afegir suport per a Pendent al camp de notes

### DIFF
--- a/build/version.js
+++ b/build/version.js
@@ -1,1 +1,1 @@
-export const version = '1.12.0';
+export const version = '1.12.1';

--- a/dist/script.user.js
+++ b/dist/script.user.js
@@ -24692,7 +24692,7 @@
       container.appendChild(contentWrapper);
       const instructionsDiv = document.createElement("div");
       instructionsDiv.className = "powertoy-instructions";
-      instructionsDiv.textContent = "Valors acceptats: 5-10 \u2192 Assolit, NA \u2192 No assolit, EP \u2192 En proc\xE9s, P/PDT \u2192 Pendent.";
+      instructionsDiv.textContent = "Valors acceptats: >=4.5 \u2192 Assolit, <4.5 \xF3 NA \u2192 No assolit, EP \u2192 En proc\xE9s, P \xF3 PDT \u2192 Pendent, . \xF3 X \u2192 Blanc";
       Object.assign(instructionsDiv.style, {
         fontSize: "0.85em",
         marginTop: "8px",

--- a/dist/script.user.js
+++ b/dist/script.user.js
@@ -23855,7 +23855,7 @@
       this.onPosaPendents = onPosaPendents;
       this.containerBuilder = containerBuilder;
     }
-    createHTML(materies) {
+    createHTML(materies, instruccions = null) {
       this.logger.log("MateriaUIBuilder \u2192 inici");
       const tableWrapper = document.createElement("div");
       tableWrapper.className = "powertoy-table-wrapper";
@@ -23918,7 +23918,7 @@
       }
       tableWrapper.appendChild(table);
       this.logger.log("MateriaUIBuilder \u2192 component creat");
-      return this.containerBuilder.createContainer(tableWrapper, "powertoy-div");
+      return this.containerBuilder.createContainer(tableWrapper, "powertoy-div", instruccions);
     }
   };
 
@@ -24632,9 +24632,10 @@
      * Crea un contenidor HTML estàndard i hi insereix l'element de contingut personalitzat.
      * @param {HTMLElement} contentElement - Element HTML a mostrar dins del contenidor.
      * @param {string} id - ID únic del contenidor (per defecte: 'powertoy-div').
+     * @param {string} instruccions - string per a inserir les instruccions.
      * @returns {HTMLElement} - El contenidor creat.
      */
-    createContainer(contentElement, id = "powertoy-div") {
+    createContainer(contentElement, id = "powertoy-div", instruccions = null) {
       this.logger.log(`ContainerUIBuilder \u2192 creant contenidor: ${id}`);
       const container = document.createElement("div");
       container.id = id;
@@ -24672,15 +24673,18 @@
       const contentWrapper = document.createElement("div");
       contentWrapper.className = "powertoy-content-wrapper";
       contentWrapper.appendChild(contentElement);
-      const instructionsDiv = document.createElement("div");
-      instructionsDiv.className = "powertoy-instructions";
-      instructionsDiv.textContent = "Valors acceptats: >=4.5 \u2192 Assolit, <4.5 o NA \u2192 No assolit, EP \u2192 En proc\xE9s, P o PDT \u2192 Pendent, . o X \u2192 Blanc";
-      Object.assign(instructionsDiv.style, {
-        fontSize: "0.85em",
-        marginTop: "8px",
-        color: "#555"
-      });
-      contentWrapper.appendChild(instructionsDiv);
+      const textInstruccions = instruccions;
+      if (textInstruccions) {
+        const instructionsDiv = document.createElement("div");
+        instructionsDiv.className = "powertoy-instructions";
+        instructionsDiv.textContent = textInstruccions;
+        Object.assign(instructionsDiv.style, {
+          fontSize: "0.85em",
+          marginTop: "8px",
+          color: "#555"
+        });
+        contentWrapper.appendChild(instructionsDiv);
+      }
       const actualitzaEstatToggle = (expanded) => {
         toggleBtn.textContent = expanded ? "\u2212" : "+";
         toggleBtn.setAttribute("aria-expanded", String(expanded));
@@ -24815,7 +24819,8 @@
         this.lastStudent = studentName;
         this.logger.log(`reinicialitza \u2192 processant alumne: ${studentName}`);
         const materies = this.parser.parse(Array.from(files));
-        const html = this.uiBuilder.createHTML(materies);
+        const instruccions = "Valors acceptats: >=4.5 \u2192 Assolit, <4.5 o NA \u2192 No assolit, EP \u2192 En proc\xE9s, P o PDT \u2192 Pendent, . o X \u2192 Blanc";
+        const html = this.uiBuilder.createHTML(materies, instruccions);
         this.containerBuilder.insertDiv(html, form);
       }, 100);
     }

--- a/dist/script.user.js
+++ b/dist/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Esfer@ PowerToys
 // @namespace    https://github.com/ctrl-alt-d/EsferaPowerToys
-// @version      1.12.0
+// @version      1.12.1
 // @description  Millores per a la plataforma Esfer@
 // @author       ctrl-alt-d
 // @license      MIT
@@ -23943,6 +23943,7 @@
         const vNet = v.replace(",", ".").trim().toUpperCase();
         if (vNet === "" || vNet === "." || vNet === "X") return "";
         if (/^A(10|[5-9])$|^NA$|^EP$|^PDT$/.test(vNet)) return vNet;
+        if (vNet === "P") return "PDT";
         if (vNet.startsWith("PENDENT") || vNet === "NP") return "PDT";
         const num = parseFloat(vNet);
         if (isNaN(num)) return null;
@@ -24037,7 +24038,7 @@
   };
 
   // build/version.js
-  var version = "1.12.0";
+  var version = "1.12.1";
 
   // src/CSSApplier.js
   var CSSApplier = class {
@@ -24689,6 +24690,15 @@
       });
       container.appendChild(toggleBtn);
       container.appendChild(contentWrapper);
+      const instructionsDiv = document.createElement("div");
+      instructionsDiv.className = "powertoy-instructions";
+      instructionsDiv.textContent = "Valors acceptats: 5-10 \u2192 Assolit, NA \u2192 No assolit, EP \u2192 En proc\xE9s, P/PDT \u2192 Pendent.";
+      Object.assign(instructionsDiv.style, {
+        fontSize: "0.85em",
+        marginTop: "8px",
+        color: "#555"
+      });
+      container.appendChild(instructionsDiv);
       const versionDiv = document.createElement("div");
       versionDiv.innerHTML = `<a href="https://github.com/ctrl-alt-d/EsferaPowerToys" target="_blank" style="text-decoration:none;">Esfer@ Power Toys</a> v. ${this.version}`;
       versionDiv.className = "powertoy-version";

--- a/dist/script.user.js
+++ b/dist/script.user.js
@@ -24672,6 +24672,15 @@
       const contentWrapper = document.createElement("div");
       contentWrapper.className = "powertoy-content-wrapper";
       contentWrapper.appendChild(contentElement);
+      const instructionsDiv = document.createElement("div");
+      instructionsDiv.className = "powertoy-instructions";
+      instructionsDiv.textContent = "Valors acceptats: >=4.5 \u2192 Assolit, <4.5 o NA \u2192 No assolit, EP \u2192 En proc\xE9s, P o PDT \u2192 Pendent, . o X \u2192 Blanc";
+      Object.assign(instructionsDiv.style, {
+        fontSize: "0.85em",
+        marginTop: "8px",
+        color: "#555"
+      });
+      contentWrapper.appendChild(instructionsDiv);
       const actualitzaEstatToggle = (expanded) => {
         toggleBtn.textContent = expanded ? "\u2212" : "+";
         toggleBtn.setAttribute("aria-expanded", String(expanded));
@@ -24690,18 +24699,16 @@
       });
       container.appendChild(toggleBtn);
       container.appendChild(contentWrapper);
-      const instructionsDiv = document.createElement("div");
-      instructionsDiv.className = "powertoy-instructions";
-      instructionsDiv.textContent = "Valors acceptats: >=4.5 \u2192 Assolit, <4.5 \xF3 NA \u2192 No assolit, EP \u2192 En proc\xE9s, P \xF3 PDT \u2192 Pendent, . \xF3 X \u2192 Blanc";
-      Object.assign(instructionsDiv.style, {
-        fontSize: "0.85em",
-        marginTop: "8px",
-        color: "#555"
-      });
-      container.appendChild(instructionsDiv);
       const versionDiv = document.createElement("div");
-      versionDiv.innerHTML = `<a href="https://github.com/ctrl-alt-d/EsferaPowerToys" target="_blank" style="text-decoration:none;">Esfer@ Power Toys</a> v. ${this.version}`;
       versionDiv.className = "powertoy-version";
+      const projectLink = document.createElement("a");
+      projectLink.href = "https://github.com/ctrl-alt-d/EsferaPowerToys";
+      projectLink.target = "_blank";
+      projectLink.rel = "noopener noreferrer";
+      projectLink.style.textDecoration = "none";
+      projectLink.textContent = "Esfer@ Power Toys";
+      versionDiv.appendChild(projectLink);
+      versionDiv.appendChild(document.createTextNode(` v. ${this.version}`));
       Object.assign(versionDiv.style, {
         textAlign: "right",
         fontSize: "0.8em",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esferapowertoys",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Millores personalitzades per a la plataforma Esfer@ d'avaluació del Departament d'Educació de la Generalitat de Catalunya.",
   "main": "esbuild.config.js",
   "directories": {

--- a/src/ContainerUIBuilder.js
+++ b/src/ContainerUIBuilder.js
@@ -17,9 +17,10 @@ export class ContainerUIBuilder {
      * Crea un contenidor HTML estàndard i hi insereix l'element de contingut personalitzat.
      * @param {HTMLElement} contentElement - Element HTML a mostrar dins del contenidor.
      * @param {string} id - ID únic del contenidor (per defecte: 'powertoy-div').
+     * @param {string} instruccions - string per a inserir les instruccions.
      * @returns {HTMLElement} - El contenidor creat.
      */
-    createContainer(contentElement, id = 'powertoy-div') {
+    createContainer(contentElement, id = 'powertoy-div', instruccions = null) {
         this.logger.log(`ContainerUIBuilder → creant contenidor: ${id}`);
         const container = document.createElement('div');
         container.id = id;
@@ -61,15 +62,19 @@ export class ContainerUIBuilder {
         contentWrapper.className = 'powertoy-content-wrapper';
         contentWrapper.appendChild(contentElement);
 
-        const instructionsDiv = document.createElement('div');
-        instructionsDiv.className = 'powertoy-instructions';
-        instructionsDiv.textContent = 'Valors acceptats: >=4.5 → Assolit, <4.5 o NA → No assolit, EP → En procés, P o PDT → Pendent, . o X → Blanc';
-        Object.assign(instructionsDiv.style, {
-            fontSize: '0.85em',
-            marginTop: '8px',
-            color: '#555'
-        });
-        contentWrapper.appendChild(instructionsDiv);
+        const textInstruccions = instruccions;
+        if(textInstruccions)
+        {
+            const instructionsDiv = document.createElement('div');
+            instructionsDiv.className = 'powertoy-instructions';
+            instructionsDiv.textContent = textInstruccions;
+            Object.assign(instructionsDiv.style, {
+                fontSize: '0.85em',
+                marginTop: '8px',
+                color: '#555'
+            });
+            contentWrapper.appendChild(instructionsDiv);
+        }
 
         const actualitzaEstatToggle = (expanded) => {
             toggleBtn.textContent = expanded ? '−' : '+';

--- a/src/ContainerUIBuilder.js
+++ b/src/ContainerUIBuilder.js
@@ -82,6 +82,16 @@ export class ContainerUIBuilder {
         container.appendChild(toggleBtn);
         container.appendChild(contentWrapper);
 
+        const instructionsDiv = document.createElement('div');
+        instructionsDiv.className = 'powertoy-instructions';
+        instructionsDiv.textContent = 'Valors acceptats: 5-10 → Assolit, NA → No assolit, EP → En procés, P/PDT → Pendent.';
+        Object.assign(instructionsDiv.style, {
+            fontSize: '0.85em',
+            marginTop: '8px',
+            color: '#555'
+        });
+        container.appendChild(instructionsDiv);
+
         const versionDiv = document.createElement('div');
         versionDiv.innerHTML = `<a href="https://github.com/ctrl-alt-d/EsferaPowerToys" target="_blank" style="text-decoration:none;">Esfer@ Power Toys</a> v. ${this.version}`;
         versionDiv.className = 'powertoy-version';

--- a/src/ContainerUIBuilder.js
+++ b/src/ContainerUIBuilder.js
@@ -61,6 +61,16 @@ export class ContainerUIBuilder {
         contentWrapper.className = 'powertoy-content-wrapper';
         contentWrapper.appendChild(contentElement);
 
+        const instructionsDiv = document.createElement('div');
+        instructionsDiv.className = 'powertoy-instructions';
+        instructionsDiv.textContent = 'Valors acceptats: >=4.5 → Assolit, <4.5 o NA → No assolit, EP → En procés, P o PDT → Pendent, . o X → Blanc';
+        Object.assign(instructionsDiv.style, {
+            fontSize: '0.85em',
+            marginTop: '8px',
+            color: '#555'
+        });
+        contentWrapper.appendChild(instructionsDiv);
+
         const actualitzaEstatToggle = (expanded) => {
             toggleBtn.textContent = expanded ? '−' : '+';
             toggleBtn.setAttribute('aria-expanded', String(expanded));
@@ -82,19 +92,16 @@ export class ContainerUIBuilder {
         container.appendChild(toggleBtn);
         container.appendChild(contentWrapper);
 
-        const instructionsDiv = document.createElement('div');
-        instructionsDiv.className = 'powertoy-instructions';
-        instructionsDiv.textContent = 'Valors acceptats: >=4.5 → Assolit, <4.5 ó NA → No assolit, EP → En procés, P ó PDT → Pendent, . ó X → Blanc';
-        Object.assign(instructionsDiv.style, {
-            fontSize: '0.85em',
-            marginTop: '8px',
-            color: '#555'
-        });
-        container.appendChild(instructionsDiv);
-
         const versionDiv = document.createElement('div');
-        versionDiv.innerHTML = `<a href="https://github.com/ctrl-alt-d/EsferaPowerToys" target="_blank" style="text-decoration:none;">Esfer@ Power Toys</a> v. ${this.version}`;
         versionDiv.className = 'powertoy-version';
+        const projectLink = document.createElement('a');
+        projectLink.href = 'https://github.com/ctrl-alt-d/EsferaPowerToys';
+        projectLink.target = '_blank';
+        projectLink.rel = 'noopener noreferrer';
+        projectLink.style.textDecoration = 'none';
+        projectLink.textContent = 'Esfer@ Power Toys';
+        versionDiv.appendChild(projectLink);
+        versionDiv.appendChild(document.createTextNode(` v. ${this.version}`));
         Object.assign(versionDiv.style, {
             textAlign: 'right',
             fontSize: '0.8em',

--- a/src/ContainerUIBuilder.js
+++ b/src/ContainerUIBuilder.js
@@ -84,7 +84,7 @@ export class ContainerUIBuilder {
 
         const instructionsDiv = document.createElement('div');
         instructionsDiv.className = 'powertoy-instructions';
-        instructionsDiv.textContent = 'Valors acceptats: 5-10 → Assolit, NA → No assolit, EP → En procés, P/PDT → Pendent.';
+        instructionsDiv.textContent = 'Valors acceptats: >=4.5 → Assolit, <4.5 ó NA → No assolit, EP → En procés, P ó PDT → Pendent, . ó X → Blanc';
         Object.assign(instructionsDiv.style, {
             fontSize: '0.85em',
             marginTop: '8px',

--- a/src/PowerToysController.js
+++ b/src/PowerToysController.js
@@ -122,7 +122,8 @@ export class PowerToysController {
 
             this.logger.log(`reinicialitza → processant alumne: ${studentName}`);
             const materies = this.parser.parse(Array.from(files));
-            const html = this.uiBuilder.createHTML(materies);
+            const instruccions = 'Valors acceptats: >=4.5 → Assolit, <4.5 o NA → No assolit, EP → En procés, P o PDT → Pendent, . o X → Blanc';
+            const html = this.uiBuilder.createHTML(materies, instruccions);
             this.containerBuilder.insertDiv(html, form);
         }, 100);
     }

--- a/src/materia/MateriaApplier.js
+++ b/src/materia/MateriaApplier.js
@@ -25,6 +25,7 @@ export class MateriaApplier {
             const vNet = v.replace(',', '.').trim().toUpperCase();
             if (vNet === '' || vNet === '.' || vNet === 'X') return '';
             if (/^A(10|[5-9])$|^NA$|^EP$|^PDT$/.test(vNet)) return vNet;
+            if (vNet === 'P') return 'PDT';
             if (vNet.startsWith('PENDENT') || vNet === 'NP') return 'PDT';
             const num = parseFloat(vNet);
             if (isNaN(num)) return null;

--- a/tests/ContainerUIBuilder.test.js
+++ b/tests/ContainerUIBuilder.test.js
@@ -40,4 +40,17 @@ describe('ContainerUIBuilder', () => {
     expect(toggle.getAttribute('aria-label')).toBe('Minimitza PowerToys');
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
   });
+
+  test('hauria de mostrar les instruccions abans de la versió', () => {
+    const builder = new ContainerUIBuilder({ log: jest.fn() }, '1.0.0');
+    const content = document.createElement('div');
+
+    const container = builder.createContainer(content, 'powertoy-test');
+    const instructions = container.querySelector('.powertoy-instructions');
+    const version = container.querySelector('.powertoy-version');
+
+    expect(instructions).not.toBeNull();
+    expect(instructions.textContent).toContain('P/PDT → Pendent');
+    expect(version.previousElementSibling).toBe(instructions);
+  });
 });

--- a/tests/ContainerUIBuilder.test.js
+++ b/tests/ContainerUIBuilder.test.js
@@ -19,7 +19,7 @@ describe('ContainerUIBuilder', () => {
     const content = document.createElement('div');
     content.textContent = 'Contingut';
 
-    const container = builder.createContainer(content, 'powertoy-test');
+    const container = builder.createContainer(content, 'powertoy-test', 'Valors acceptats: >=4.5 → Assolit, <4.5 o NA → No assolit, EP → En procés, P o PDT → Pendent, . o X → Blanc');
     const toggle = container.querySelector('#powertoy-test-toggle-btn');
     const wrapper = container.querySelector('.powertoy-content-wrapper');
 
@@ -46,7 +46,7 @@ describe('ContainerUIBuilder', () => {
     const builder = new ContainerUIBuilder({ log: jest.fn() }, '1.0.0');
     const content = document.createElement('div');
 
-    const container = builder.createContainer(content, 'powertoy-test');
+    const container = builder.createContainer(content, 'powertoy-test', 'Valors acceptats: >=4.5 → Assolit, <4.5 o NA → No assolit, EP → En procés, P o PDT → Pendent, . o X → Blanc');
     const wrapper = container.querySelector('.powertoy-content-wrapper');
     const instructions = container.querySelector('.powertoy-instructions');
     const version = container.querySelector('.powertoy-version');

--- a/tests/ContainerUIBuilder.test.js
+++ b/tests/ContainerUIBuilder.test.js
@@ -30,6 +30,7 @@ describe('ContainerUIBuilder', () => {
     toggle.click();
 
     expect(wrapper.style.display).toBe('none');
+    expect(wrapper.querySelector('.powertoy-instructions')).not.toBeNull();
     expect(toggle.getAttribute('aria-label')).toBe('Expandeix PowerToys');
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(toggle.title).toBe('Expandeix PowerToys');
@@ -41,16 +42,33 @@ describe('ContainerUIBuilder', () => {
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
   });
 
-  test('hauria de mostrar les instruccions abans de la versió', () => {
+  test('hauria de mostrar les instruccions dins del contingut i abans de la versió', () => {
     const builder = new ContainerUIBuilder({ log: jest.fn() }, '1.0.0');
     const content = document.createElement('div');
 
     const container = builder.createContainer(content, 'powertoy-test');
+    const wrapper = container.querySelector('.powertoy-content-wrapper');
     const instructions = container.querySelector('.powertoy-instructions');
     const version = container.querySelector('.powertoy-version');
 
     expect(instructions).not.toBeNull();
     expect(instructions.textContent).toContain('Valors acceptats:');
-    expect(version.previousElementSibling).toBe(instructions);
+    expect(instructions.textContent).toContain('<4.5 o NA');
+    expect(instructions.textContent).toContain('P o PDT');
+    expect(instructions.textContent).toContain('. o X');
+    expect(wrapper.contains(instructions)).toBe(true);
+    expect(version.previousElementSibling).toBe(wrapper);
+  });
+
+  test('hauria de crear l’enllaç de versió sense innerHTML i amb rel segur', () => {
+    const builder = new ContainerUIBuilder({ log: jest.fn() }, '1.0.0');
+    const content = document.createElement('div');
+
+    const container = builder.createContainer(content, 'powertoy-test');
+    const link = container.querySelector('.powertoy-version a');
+
+    expect(link.textContent).toBe('Esfer@ Power Toys');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toBe('noopener noreferrer');
   });
 });

--- a/tests/ContainerUIBuilder.test.js
+++ b/tests/ContainerUIBuilder.test.js
@@ -50,7 +50,7 @@ describe('ContainerUIBuilder', () => {
     const version = container.querySelector('.powertoy-version');
 
     expect(instructions).not.toBeNull();
-    expect(instructions.textContent).toContain('P/PDT → Pendent');
+    expect(instructions.textContent).toContain('Valors acceptats:');
     expect(version.previousElementSibling).toBe(instructions);
   });
 });

--- a/tests/MateriaApplier.test.js
+++ b/tests/MateriaApplier.test.js
@@ -1,0 +1,10 @@
+import { jest, describe, test, expect } from '@jest/globals';
+import { MateriaApplier } from '../src/materia/MateriaApplier.js';
+
+describe('MateriaApplier', () => {
+    test('hauria de traduir P i p com a Pendent', () => {
+        const applier = new MateriaApplier({ log: jest.fn(), warn: jest.fn() });
+
+        expect(applier.tradueixNotes('P p')).toEqual(['PDT', 'PDT']);
+    });
+});


### PR DESCRIPTION
## Resum
- Permet escriure `P` o `p` al camp de notes per aplicar `PDT` a Esfer@.
- Afegeix instruccions visibles amb els valors acceptats abans del peu de versió.
- Puja la versió a `1.12.1` i regenera el userscript.

## Validació
- `pnpm test`
- `pnpm run build`